### PR TITLE
Regexp input delimiter

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -24,6 +24,8 @@ type DelimiterOption struct {
 	Input string
 	// --output-delimiter
 	OutPut string
+	// --remove-empty
+	RemoveEmpty bool
 }
 
 // InputFiles is setting for -f, --input-files option


### PR DESCRIPTION
入力のデリミタに正規表現を使えるようにしたのと、文字列の長さが0なカラムを取り除く `-r/--remove-empty` オプションを追加した