### PR TITLE
refactor(iterator): IEnumerableを Source と Columns に分割してpanic実装をなくす

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,14 @@ golangci-lint run
    - `RangeSelector` - Range with optional step (Python slice notation)
    - `SwitchSelector` - Regex-based range selection with +N/-N context support
 
-3. **Iterators** (`internal/iterator/`) - Line splitting strategies via `IEnumerable` interface:
-   - `Iterator` - On-demand string splitting
-   - `RegexpIterator` - Regex-based splitting
-   - `PreSplitIterator` - Pre-split all columns (for `-S` flag or CSV/TSV)
+3. **Iterators** (`internal/iterator/`) - Split into two interfaces:
+   - `Source` - Supplies one `Columns` per line/record, `io.EOF` at the end. `cmd/root.go` drives this loop
+     - `lineSource` - Reads lines with `bufio` and hands them to a splitting `Columns`
+     - `csvSource` - Reads records with `encoding/csv` (already split)
+   - `Columns` - Per-line column view (`ElementAt` / `ToArray`). The only thing `Selector` sees
+     - `Iterator` - On-demand string splitting
+     - `RegexpIterator` - Regex-based splitting
+     - `PreSplitIterator` - Pre-split all columns (for `-S` flag or CSV/TSV)
 
 4. **Output** (`internal/output/`) - `Writer` handles delimiter joining and template-based output
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"bufio"
-	"encoding/csv"
-	"github.com/xztaityozx/sel/internal/iterator"
-	"github.com/xztaityozx/sel/internal/output"
+	"errors"
 	"io"
 	"log"
 	"os"
@@ -13,7 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/xztaityozx/sel/internal/column"
+	"github.com/xztaityozx/sel/internal/iterator"
 	"github.com/xztaityozx/sel/internal/option"
+	"github.com/xztaityozx/sel/internal/output"
 	"github.com/xztaityozx/sel/internal/parser"
 )
 
@@ -138,61 +137,33 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 }
 
 // run はあるファイルについて column.Selector によるカラム選択と column.Writer による書き出しを行う。ファイルはCloseされる
-func run(input *os.File, option option.Option, w *output.Writer, selectors []column.Selector) error {
+func run(input *os.File, opt option.Option, w *output.Writer, selectors []column.Selector) error {
 	defer func(input *os.File) {
 		if err := input.Close(); err != nil {
 			log.Fatalln(err)
 		}
 	}(input)
 
-	iter, err := iterator.NewIEnumerable(option)
+	src, err := iterator.NewSource(opt, input)
 	if err != nil {
 		return err
 	}
 
 	var fillMissing *string
-	if option.IgnoreMissing {
-		fillMissing = &option.FillMissing
+	if opt.IgnoreMissing {
+		fillMissing = &opt.FillMissing
 	}
 
-	if ok, comma := option.IsXsv(); ok {
-		r := csv.NewReader(input)
-		r.Comma = comma
-
-		var record []string
-		var csvReadError error
-		for {
-			record, csvReadError = r.Read()
-			if csvReadError != nil && csvReadError != io.EOF {
-				return csvReadError
-			}
-			if csvReadError == io.EOF {
-				break
-			}
-
-			iter.ResetFromArray(record)
-
-			if err := selectAll(&iter, w, selectors, fillMissing); err != nil {
-				return err
-			}
-		}
-
-		return w.Flush()
-	}
-
-	reader := bufio.NewReader(input)
 	for {
-		line, err := reader.ReadString('\n')
-		if len(line) > 0 {
-			iter.Reset(strings.TrimRight(line, "\n"))
-			if err := selectAll(&iter, w, selectors, fillMissing); err != nil {
-				return err
-			}
-		}
+		columns, err := src.Next()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
+			return err
+		}
+
+		if err := selectAll(columns, w, selectors, fillMissing); err != nil {
 			return err
 		}
 	}
@@ -200,9 +171,9 @@ func run(input *os.File, option option.Option, w *output.Writer, selectors []col
 	return w.Flush()
 }
 
-func selectAll(iter *iterator.IEnumerable, w *output.Writer, selectors []column.Selector, fillMissing *string) error {
+func selectAll(columns iterator.Columns, w *output.Writer, selectors []column.Selector, fillMissing *string) error {
 	for _, selector := range selectors {
-		err := selector.Select(w, *iter)
+		err := selector.Select(w, columns)
 		if err != nil {
 			if fillMissing != nil && err.Error() == iterator.IndexOutOfRange {
 				if *fillMissing != "" {

--- a/internal/column/index.go
+++ b/internal/column/index.go
@@ -23,7 +23,7 @@ func NewIndexSelectorFromString(str string, def int) (IndexSelector, error) {
 	return NewIndexSelector(num), err
 }
 
-func (i IndexSelector) Select(w *output.Writer, iter iterator.IEnumerable) error {
+func (i IndexSelector) Select(w *output.Writer, iter iterator.Columns) error {
 
 	if i.index == 0 {
 		return w.Write(iter.ToArray()...)

--- a/internal/column/range.go
+++ b/internal/column/range.go
@@ -18,7 +18,7 @@ func NewRangeSelector(start, step, stop int, isInfStop bool) RangeSelector {
 	return RangeSelector{start: start, step: step, stop: stop, isInfStop: isInfStop}
 }
 
-func (r RangeSelector) Select(w *output.Writer, iter iterator.IEnumerable) error {
+func (r RangeSelector) Select(w *output.Writer, iter iterator.Columns) error {
 	strings := iter.ToArray()
 	m := len(strings)
 

--- a/internal/column/range_test.go
+++ b/internal/column/range_test.go
@@ -64,7 +64,7 @@ func TestRangeSelector_Select(t *testing.T) {
 			rs := NewRangeSelector(v.start, v.step, v.stop, false)
 			expect := expectFactory(v.expects)
 			writer := output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)
-			err := rs.Select(writer, &testEnumerable{a: cols})
+			err := rs.Select(writer, &testColumns{a: cols})
 			assert.Nil(t, writer.Flush())
 			assert.Nil(t, err)
 			assert.Equal(t, strings.Join(expect, " "), w.String(), "start: %d, step: %d, stop: %d", v.start, v.step, v.stop)
@@ -86,7 +86,7 @@ func TestRangeSelector_Select(t *testing.T) {
 		for _, v := range dataset {
 			rs := NewRangeSelector(v.start, v.step, v.stop, false)
 			writer := output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)
-			err := rs.Select(writer, &testEnumerable{a: cols})
+			err := rs.Select(writer, &testColumns{a: cols})
 			assert.Nil(t, writer.Flush())
 			assert.NotNil(t, err)
 			assert.Equal(t, 0, len(w.String()))
@@ -97,7 +97,7 @@ func TestRangeSelector_Select(t *testing.T) {
 	t.Run("Inf", func(t *testing.T) {
 		rs := NewRangeSelector(1, 1, 1, true)
 		writer := output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)
-		err := rs.Select(writer, &testEnumerable{a: cols})
+		err := rs.Select(writer, &testColumns{a: cols})
 		assert.Nil(t, writer.Flush())
 		assert.Nil(t, err)
 		assert.Equal(t, strings.Join(cols, " "), w.String())
@@ -114,7 +114,7 @@ func BenchmarkRangeSelector_Select_Forward(b *testing.B) {
 	writer := output.NewWriter(opt, io.Discard, false)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = rs.Select(writer, &testEnumerable{a: cols})
+		_ = rs.Select(writer, &testColumns{a: cols})
 		_ = writer.WriteNewLine()
 	}
 }
@@ -129,7 +129,7 @@ func BenchmarkRangeSelector_Select_Backward(b *testing.B) {
 	writer := output.NewWriter(opt, io.Discard, false)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = rs.Select(writer, &testEnumerable{a: cols})
+		_ = rs.Select(writer, &testColumns{a: cols})
 		_ = writer.WriteNewLine()
 	}
 }
@@ -144,7 +144,7 @@ func BenchmarkRangeSelector_Select_Step(b *testing.B) {
 	writer := output.NewWriter(opt, io.Discard, false)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = rs.Select(writer, &testEnumerable{a: cols})
+		_ = rs.Select(writer, &testColumns{a: cols})
 		_ = writer.WriteNewLine()
 	}
 }

--- a/internal/column/selector.go
+++ b/internal/column/selector.go
@@ -6,5 +6,5 @@ import (
 )
 
 type Selector interface {
-	Select(w *output.Writer, iterator iterator.IEnumerable) error
+	Select(w *output.Writer, columns iterator.Columns) error
 }

--- a/internal/column/switch.go
+++ b/internal/column/switch.go
@@ -55,7 +55,7 @@ func abs(a int) int {
 }
 
 // Select はクエリに従ってカラムを選択する
-func (s SwitchSelector) Select(w *output.Writer, iter iterator.IEnumerable) error {
+func (s SwitchSelector) Select(w *output.Writer, iter iterator.Columns) error {
 	// isAroundContextなときは、配列の最大長が必要になるので、最初に全部分割してしまう
 	strings := iter.ToArray()
 	maximum := len(strings)

--- a/internal/column/switch_test.go
+++ b/internal/column/switch_test.go
@@ -41,31 +41,18 @@ func TestNewSwitchSelector(t *testing.T) {
 	}
 }
 
-type testEnumerable struct {
+// testColumns は ToArray だけを返す iterator.Columns のテスト用実装
+type testColumns struct {
 	a []string
 }
 
-func (t *testEnumerable) ResetFromArray(_ []string) {
+var _ iterator.Columns = (*testColumns)(nil)
+
+func (t *testColumns) ElementAt(_ int) (string, error) {
 	panic("implement me")
 }
 
-func (t *testEnumerable) ElementAt(_ int) (string, error) {
-	panic("implement me")
-}
-
-func (t *testEnumerable) Next() (item string, ok bool) {
-	panic("implement me")
-}
-
-func (t *testEnumerable) Last() (item string, ok bool) {
-	panic("implement me")
-}
-
-func (t *testEnumerable) Reset(_ string) {
-	panic("implement me")
-}
-
-func (t *testEnumerable) ToArray() []string {
+func (t *testColumns) ToArray() []string {
 	return t.a
 }
 
@@ -76,7 +63,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 	}
 	type args struct {
 		w    *output.Writer
-		iter iterator.IEnumerable
+		iter iterator.Columns
 	}
 
 	var cols []string
@@ -100,7 +87,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{num: 1},
 				end:   endAddress{address: address{num: 5}},
 			},
-			args: args{iter: &testEnumerable{a: cols}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: cols}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: cols[0:5],
 		},
 		{
@@ -109,7 +96,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`a`)},
 				end:   endAddress{address{regexp: regexp.MustCompile(`e`)}, false},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"a", "b", "c", "d", "e"},
 		},
 		{
@@ -118,7 +105,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`a`)},
 				end:   endAddress{address{num: 5}, true},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"a", "b", "c", "d", "e", "3"},
 		},
 		{
@@ -127,7 +114,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`e`)},
 				end:   endAddress{address{num: -5}, true},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"2", "a", "b", "c", "d", "e"},
 		},
 		{
@@ -136,7 +123,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`a`)},
 				end:   endAddress{address{num: -5}, true},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"1", "2", "a"},
 		},
 		{
@@ -145,7 +132,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`e`)},
 				end:   endAddress{address{num: 5}, true},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"e", "3", "4"},
 		},
 		{
@@ -154,7 +141,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`e`)},
 				end:   endAddress{address{num: 0}, true},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"e"},
 		},
 		{
@@ -163,7 +150,7 @@ func TestSwitchSelector_Select(t *testing.T) {
 				begin: address{regexp: regexp.MustCompile(`e`)},
 				end:   endAddress{address{num: 0}, false},
 			},
-			args: args{iter: &testEnumerable{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
+			args: args{iter: &testColumns{a: []string{"1", "2", "a", "b", "c", "d", "e", "3", "4"}}, w: output.NewWriter(option.Option{DelimiterOption: option.DelimiterOption{OutPutDelimiter: " "}}, w, true)},
 			want: []string{"e", "3", "4"},
 		},
 	}

--- a/internal/iterator/columns.go
+++ b/internal/iterator/columns.go
@@ -1,0 +1,52 @@
+package iterator
+
+import (
+	"regexp"
+
+	"github.com/xztaityozx/sel/internal/option"
+)
+
+// Columns は1行ぶんのカラム列を表す。column.Selector が触るのはこのインターフェースだけ
+type Columns interface {
+	// ElementAt は idx 番目のカラムを返す。1-indexed で、負の値は末尾からの位置を表す
+	ElementAt(idx int) (string, error)
+	// ToArray はすべてのカラムを配列にして返す
+	ToArray() []string
+}
+
+// splitColumns は「1行の文字列」から作り直せる Columns。行を供給する lineSource が使う
+type splitColumns interface {
+	Columns
+	// Reset は s を新しい1行として受け取り、分割状態を作り直す
+	Reset(s string)
+}
+
+var (
+	_ splitColumns = (*Iterator)(nil)
+	_ splitColumns = (*RegexpIterator)(nil)
+	_ splitColumns = (*PreSplitIterator)(nil)
+)
+
+// newSplitColumns は option.Option から適切な splitColumns を生成して返す
+func newSplitColumns(option option.Option) (splitColumns, error) {
+	if option.UseRegexp {
+		r, err := regexp.Compile(option.InputDelimiter)
+		if err != nil {
+			return nil, err
+		}
+
+		if option.SplitBefore {
+			// 事前に分割する。選択しないカラムも分割するが、後半のカラムを選択するときにはこちらが有利
+			return NewPreSplitByRegexpIterator("", r, option.RemoveEmpty), nil
+		}
+		// 欲しいところまでの分割を都度行う。前の方にあるindexを選ぶほど有利
+		// 負のindexを指定する場合は、末尾まで分割してから返すような実装なので、実行速度が低下してしまうことに注意
+		// もしかしたら肯定先読みとか使えば後ろからsplitできたりする？
+		return NewRegexpIterator("", r, option.RemoveEmpty), nil
+	}
+
+	if option.SplitBefore {
+		return NewPreSplitIterator("", option.InputDelimiter, option.RemoveEmpty), nil
+	}
+	return NewIterator("", option.InputDelimiter, option.RemoveEmpty), nil
+}

--- a/internal/iterator/columns.go
+++ b/internal/iterator/columns.go
@@ -21,12 +21,6 @@ type splitColumns interface {
 	Reset(s string)
 }
 
-var (
-	_ splitColumns = (*Iterator)(nil)
-	_ splitColumns = (*RegexpIterator)(nil)
-	_ splitColumns = (*PreSplitIterator)(nil)
-)
-
 // newSplitColumns は option.Option から適切な splitColumns を生成して返す
 func newSplitColumns(option option.Option) (splitColumns, error) {
 	if option.UseRegexp {

--- a/internal/iterator/iterator.go
+++ b/internal/iterator/iterator.go
@@ -1,54 +1,11 @@
 package iterator
 
 import (
-  "errors"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/xztaityozx/sel/internal/option"
 )
-
-type IEnumerable interface {
-	ElementAt(idx int) (string, error)
-	Next() (item string, ok bool)
-	Last() (item string, ok bool)
-	ToArray() []string
-	Reset(s string)
-	ResetFromArray(a []string)
-}
-
-// NewIEnumerable は option.Option から適切な IEnumerable を生成して返す
-func NewIEnumerable(option option.Option) (IEnumerable, error) {
-
-	if ok, comma := option.IsXsv(); ok {
-		// CSV/TSVの時はencoding/csvが分割をしてくれるので、NewPreSplitIteratorを使えばよい
-		return NewPreSplitIterator("", string(comma), option.RemoveEmpty), nil
-	}
-
-	if option.UseRegexp {
-		r, err := regexp.Compile(option.InputDelimiter)
-		if err != nil {
-			return nil, err
-		}
-
-		if option.SplitBefore {
-			// 事前に分割する。選択しないカラムも分割するが、後半のカラムを選択するときにはこちらが有利
-			return NewPreSplitByRegexpIterator("", r, option.RemoveEmpty), nil
-		} else {
-			// 欲しいところまでの分割を都度行う。前の方にあるindexを選ぶほど有利
-			// 負のindexを指定する場合は、末尾まで分割してから返すような実装なので、実行速度が低下してしまうことに注意
-			// もしかしたら肯定先読みとか使えば後ろからsplitできたりする？
-			return NewRegexpIterator("", r, option.RemoveEmpty), nil
-		}
-	} else {
-		if option.SplitBefore {
-			return NewPreSplitIterator("", option.InputDelimiter, option.RemoveEmpty), nil
-		} else {
-			return NewIterator("", option.InputDelimiter, option.RemoveEmpty), nil
-		}
-	}
-}
 
 // resetStringSlice はスライスを長さ0にリセットする。
 // 容量が shrinkThreshold を超えている場合は nil を返し、backing array を GC 可能にする。
@@ -116,9 +73,9 @@ func (i *Iterator) ElementAt(idx int) (string, error) {
 			return i.front[idx-1], nil
 		}
 
-		// 足りなければ Next() で追加分割
+		// 足りなければ next() で追加分割
 		for len(i.front) < idx {
-			if _, ok := i.Next(); !ok {
+			if _, ok := i.next(); !ok {
 				break
 			}
 		}
@@ -144,9 +101,9 @@ func (i *Iterator) ElementAt(idx int) (string, error) {
 		return i.back[absIdx-1], nil
 	}
 
-	// 足りなければ Last() で追加分割
+	// 足りなければ last() で追加分割
 	for len(i.back) < absIdx {
-		if _, ok := i.Last(); !ok {
+		if _, ok := i.last(); !ok {
 			break
 		}
 	}
@@ -168,8 +125,8 @@ func (i *Iterator) ElementAt(idx int) (string, error) {
 	return "", errors.New(IndexOutOfRange)
 }
 
-// Next は先頭から次の要素を取り出す
-func (i *Iterator) Next() (item string, ok bool) {
+// next は先頭から次の要素を取り出す
+func (i *Iterator) next() (item string, ok bool) {
 	s := i.remaining
 
 	if s == "" {
@@ -187,15 +144,15 @@ func (i *Iterator) Next() (item string, ok bool) {
 	i.remaining = s[m+i.sepLen:]
 
 	if i.removeEmpty && a == "" {
-		return i.Next()
+		return i.next()
 	}
 
 	i.front = append(i.front, a)
 	return a, true
 }
 
-// Last は末尾から要素を取り出す
-func (i *Iterator) Last() (item string, ok bool) {
+// last は末尾から要素を取り出す
+func (i *Iterator) last() (item string, ok bool) {
 	s := i.remaining
 
 	if s == "" {
@@ -213,7 +170,7 @@ func (i *Iterator) Last() (item string, ok bool) {
 	i.remaining = s[:m]
 
 	if i.removeEmpty && a == "" {
-		return i.Last()
+		return i.last()
 	}
 
 	i.back = append(i.back, a)
@@ -250,10 +207,6 @@ func (i *Iterator) ToArray() []string {
 
 	i.a = a
 	return a
-}
-
-func (i *Iterator) ResetFromArray(_ []string) {
-	panic("not impl")
 }
 
 func NewIterator(s, sep string, removeEmpty bool) *Iterator {
@@ -298,9 +251,9 @@ func (r *RegexpIterator) ElementAt(idx int) (string, error) {
 			return r.front[idx-1], nil
 		}
 
-		// 足りなければ Next() で追加分割
+		// 足りなければ next() で追加分割
 		for len(r.front) < idx {
-			if _, ok := r.Next(); !ok {
+			if _, ok := r.next(); !ok {
 				break
 			}
 		}
@@ -369,7 +322,8 @@ func (r *RegexpIterator) ElementAt(idx int) (string, error) {
 	return "", errors.New(IndexOutOfRange)
 }
 
-func (r *RegexpIterator) Next() (item string, ok bool) {
+// next は先頭から次の要素を取り出す
+func (r *RegexpIterator) next() (item string, ok bool) {
 	s := r.s
 
 	if s == "" {
@@ -388,7 +342,7 @@ func (r *RegexpIterator) Next() (item string, ok bool) {
 	r.r.Reset(r.s)
 
 	if r.removeEmpty && a == "" {
-		return r.Next()
+		return r.next()
 	}
 
 	r.front = append(r.front, a)
@@ -396,17 +350,13 @@ func (r *RegexpIterator) Next() (item string, ok bool) {
 	return a, true
 }
 
-func (r *RegexpIterator) Last() (item string, ok bool) {
-	panic("not implement Last() for RegexpIterator")
-}
-
 func (r *RegexpIterator) ToArray() []string {
 	if r.a != nil {
 		return r.a
 	}
 
-	// 残りをすべて Next() で分割
-	for _, ok := r.Next(); ok; _, ok = r.Next() {
+	// 残りをすべて next() で分割
+	for _, ok := r.next(); ok; _, ok = r.next() {
 	}
 
 	// front + back(逆順) を結合
@@ -427,10 +377,6 @@ func (r *RegexpIterator) Reset(s string) {
 	r.front = resetStringSlice(r.front)
 	r.back = resetStringSlice(r.back)
 	r.a = nil
-}
-
-func (r *RegexpIterator) ResetFromArray(_ []string) {
-	panic("not impl")
 }
 
 func NewRegexpIterator(s string, sep *regexp.Regexp, re bool) *RegexpIterator {

--- a/internal/iterator/iterator_test.go
+++ b/internal/iterator/iterator_test.go
@@ -134,7 +134,7 @@ func TestIterator_ElementAt(t *testing.T) {
 	}
 }
 
-func TestIterator_Next(t *testing.T) {
+func TestIterator_next(t *testing.T) {
 	type fields struct {
 		front       []string
 		back        []string
@@ -163,18 +163,18 @@ func TestIterator_Next(t *testing.T) {
 				sepLen:      tt.fields.sepLen,
 				removeEmpty: tt.fields.removeEmpty,
 			}
-			gotItem, gotOk := i.Next()
+			gotItem, gotOk := i.next()
 			if gotItem != tt.wantItem {
-				t.Errorf("Next() gotItem = %v, want %v", gotItem, tt.wantItem)
+				t.Errorf("next() gotItem = %v, want %v", gotItem, tt.wantItem)
 			}
 			if gotOk != tt.wantOk {
-				t.Errorf("Next() gotOk = %v, want %v", gotOk, tt.wantOk)
+				t.Errorf("next() gotOk = %v, want %v", gotOk, tt.wantOk)
 			}
 		})
 	}
 }
 
-func TestIterator_Last(t *testing.T) {
+func TestIterator_last(t *testing.T) {
 	type fields struct {
 		front       []string
 		back        []string
@@ -203,12 +203,12 @@ func TestIterator_Last(t *testing.T) {
 				sepLen:      tt.fields.sepLen,
 				removeEmpty: tt.fields.removeEmpty,
 			}
-			gotItem, gotOk := i.Last()
+			gotItem, gotOk := i.last()
 			if gotItem != tt.wantItem {
-				t.Errorf("Last() gotItem = %v, want %v", gotItem, tt.wantItem)
+				t.Errorf("last() gotItem = %v, want %v", gotItem, tt.wantItem)
 			}
 			if gotOk != tt.wantOk {
-				t.Errorf("Last() gotOk = %v, want %v", gotOk, tt.wantOk)
+				t.Errorf("last() gotOk = %v, want %v", gotOk, tt.wantOk)
 			}
 		})
 	}
@@ -366,15 +366,7 @@ func TestRegexpIterator_ToArray(t *testing.T) {
 	}
 }
 
-func TestRegexpIterator_Last(t *testing.T) {
-	r := &RegexpIterator{}
-
-	assert.Panics(t, func() {
-		r.Last()
-	})
-}
-
-func TestRegexpIterator_Next(t *testing.T) {
+func TestRegexpIterator_next(t *testing.T) {
 	type fields struct {
 		r           *strings.Reader
 		sep         *regexp.Regexp
@@ -444,12 +436,12 @@ func TestRegexpIterator_Next(t *testing.T) {
 				removeEmpty: tt.fields.removeEmpty,
 				a:           tt.fields.a,
 			}
-			gotItem, gotOk := r.Next()
+			gotItem, gotOk := r.next()
 			if gotItem != tt.wantItem {
-				t.Errorf("Next() gotItem = %v, want %v", gotItem, tt.wantItem)
+				t.Errorf("next() gotItem = %v, want %v", gotItem, tt.wantItem)
 			}
 			if gotOk != tt.wantOk {
-				t.Errorf("Next() gotOk = %v, want %v", gotOk, tt.wantOk)
+				t.Errorf("next() gotOk = %v, want %v", gotOk, tt.wantOk)
 			}
 		})
 	}
@@ -604,7 +596,7 @@ func TestRegexpIterator_ElementAt(t *testing.T) {
 	}
 }
 
-func TestNewIEnumerable(t *testing.T) {
+func TestNewSplitColumns(t *testing.T) {
 	as := assert.New(t)
 	type args struct {
 		option option.Option
@@ -612,7 +604,7 @@ func TestNewIEnumerable(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		wants   IEnumerable
+		wants   splitColumns
 		wantErr bool
 	}{
 		{
@@ -637,26 +629,6 @@ func TestNewIEnumerable(t *testing.T) {
 				},
 			},
 			NewPreSplitIterator("", "", false),
-			false,
-		},
-		{
-			"to be PreSplitIterator for CSV",
-			args{
-				option.Option{
-					Xsv: option.Xsv{Csv: true, Tsv: false},
-				},
-			},
-			NewPreSplitIterator("", ",", false),
-			false,
-		},
-		{
-			"to be PreSplitIterator for Tsv",
-			args{
-				option.Option{
-					Xsv: option.Xsv{Csv: false, Tsv: true},
-				},
-			},
-			NewPreSplitIterator("", "\t", false),
 			false,
 		},
 		{
@@ -703,7 +675,7 @@ func TestNewIEnumerable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewIEnumerable(tt.args.option)
+			got, err := newSplitColumns(tt.args.option)
 			if tt.wantErr {
 				as.Error(err)
 			} else {

--- a/internal/iterator/presplit.go
+++ b/internal/iterator/presplit.go
@@ -1,15 +1,14 @@
 package iterator
 
 import (
-  "errors"
+	"errors"
 	"regexp"
 	"strings"
 )
 
+// PreSplitIterator は先に全カラムへ分割してしまう Columns
 type PreSplitIterator struct {
 	a           []string
-	head        int
-	tail        int
 	sep         string
 	reg         *regexp.Regexp
 	l           int
@@ -31,55 +30,27 @@ func (p *PreSplitIterator) ElementAt(idx int) (string, error) {
 	return p.a[idx-1], nil
 }
 
-func (p *PreSplitIterator) Next() (item string, ok bool) {
-	if p.l <= p.head {
-		return "", false
-	}
-
-	if -p.l >= p.tail {
-		return "", false
-	}
-
-	a := p.a[p.head]
-	p.head++
-	return a, true
-}
-
-func (p *PreSplitIterator) Last() (item string, ok bool) {
-	if -p.l >= p.tail {
-		return "", false
-	}
-
-	if p.l <= p.head {
-		return "", false
-	}
-
-	a := p.a[p.l+p.tail-1]
-	p.tail--
-	return a, true
-}
-
 func (p *PreSplitIterator) ToArray() []string {
 	return p.a
 }
 
 func (p *PreSplitIterator) Reset(s string) {
 	if p.reg == nil {
-		p.ResetFromArray(strings.Split(s, p.sep))
+		p.resetFromArray(strings.Split(s, p.sep))
 	} else {
-		p.ResetFromArray(p.reg.Split(s, -1))
+		p.resetFromArray(p.reg.Split(s, -1))
 	}
 }
 
-func (p *PreSplitIterator) ResetFromArray(a []string) {
+// resetFromArray は分割済みの配列をそのままカラム列として受け取る。
+// encoding/csv のように分割済みのレコードが手に入る入力で使う
+func (p *PreSplitIterator) resetFromArray(a []string) {
 	if p.removeEmpty {
 		p.a = removeEmpty(a)
 	} else {
 		p.a = a
 	}
 
-	p.tail = 0
-	p.head = 0
 	p.l = len(p.a)
 }
 
@@ -91,8 +62,6 @@ func NewPreSplitIterator(s, sep string, re bool) *PreSplitIterator {
 	p := &PreSplitIterator{
 		a:           a,
 		sep:         sep,
-		head:        0,
-		tail:        0,
 		removeEmpty: re,
 	}
 	p.l = len(p.a)
@@ -108,8 +77,6 @@ func NewPreSplitByRegexpIterator(s string, reg *regexp.Regexp, re bool) *PreSpli
 	p := &PreSplitIterator{
 		a:           a,
 		reg:         reg,
-		head:        0,
-		tail:        0,
 		removeEmpty: re,
 	}
 	p.l = len(p.a)

--- a/internal/iterator/presplit_test.go
+++ b/internal/iterator/presplit_test.go
@@ -20,24 +20,18 @@ func TestNewPreSplitByRegexpIterator(t *testing.T) {
 	}{
 		{name: "", args: args{s: "a11b22c33d", reg: regexp.MustCompile(`\d+`), re: false}, want: &PreSplitIterator{
 			a:           []string{"a", "b", "c", "d"},
-			head:        0,
-			tail:        0,
 			reg:         regexp.MustCompile(`\d+`),
 			l:           4,
 			removeEmpty: false,
 		}},
 		{name: "", args: args{s: "a11b22c33d", reg: regexp.MustCompile(`\d`), re: true}, want: &PreSplitIterator{
 			a:           []string{"a", "b", "c", "d"},
-			head:        0,
-			tail:        0,
 			reg:         regexp.MustCompile(`\d`),
 			l:           4,
 			removeEmpty: true,
 		}},
 		{name: "", args: args{s: "a11b22c33d", reg: regexp.MustCompile(`\d`), re: false}, want: &PreSplitIterator{
 			a:           []string{"a", "", "b", "", "c", "", "d"},
-			head:        0,
-			tail:        0,
 			reg:         regexp.MustCompile(`\d`),
 			l:           7,
 			removeEmpty: false,
@@ -65,8 +59,6 @@ func TestNewPreSplitIterator(t *testing.T) {
 	}{
 		{name: "split by space(no remove-empty)", args: args{s: "a b c d", sep: " ", re: false}, want: &PreSplitIterator{
 			a:           []string{"a", "b", "c", "d"},
-			head:        0,
-			tail:        0,
 			sep:         " ",
 			reg:         nil,
 			l:           4,
@@ -74,8 +66,6 @@ func TestNewPreSplitIterator(t *testing.T) {
 		}},
 		{name: "split by space(remove-empty)", args: args{s: "a b   c d", sep: " ", re: true}, want: &PreSplitIterator{
 			a:           []string{"a", "b", "c", "d"},
-			head:        0,
-			tail:        0,
 			sep:         " ",
 			reg:         nil,
 			l:           4,
@@ -83,8 +73,6 @@ func TestNewPreSplitIterator(t *testing.T) {
 		}},
 		{name: "split by space(remove-empty)", args: args{s: "a b   c d", sep: " ", re: false}, want: &PreSplitIterator{
 			a:           []string{"a", "b", "", "", "c", "d"},
-			head:        0,
-			tail:        0,
 			sep:         " ",
 			reg:         nil,
 			l:           6,
@@ -103,8 +91,6 @@ func TestNewPreSplitIterator(t *testing.T) {
 func TestPreSplitIterator_ToArray(t *testing.T) {
 	type fields struct {
 		a           []string
-		head        int
-		tail        int
 		sep         string
 		reg         *regexp.Regexp
 		l           int
@@ -122,8 +108,6 @@ func TestPreSplitIterator_ToArray(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &PreSplitIterator{
 				a:           tt.fields.a,
-				head:        tt.fields.head,
-				tail:        tt.fields.tail,
 				sep:         tt.fields.sep,
 				reg:         tt.fields.reg,
 				l:           tt.fields.l,
@@ -139,8 +123,6 @@ func TestPreSplitIterator_ToArray(t *testing.T) {
 func TestPreSplitIterator_Reset(t *testing.T) {
 	type fields struct {
 		a           []string
-		head        int
-		tail        int
 		sep         string
 		reg         *regexp.Regexp
 		l           int
@@ -154,15 +136,13 @@ func TestPreSplitIterator_Reset(t *testing.T) {
 		fields fields
 		args   args
 	}{
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 2, tail: 0, sep: " ", reg: nil, l: 2, removeEmpty: false}, args: args{s: "a b c d"}},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 2, tail: 0, sep: "", reg: regexp.MustCompile(`\d+`), l: 2, removeEmpty: false}, args: args{s: "a11b22c33d"}},
+		{name: "", fields: fields{a: []string{"1", "2"}, sep: " ", reg: nil, l: 2, removeEmpty: false}, args: args{s: "a b c d"}},
+		{name: "", fields: fields{a: []string{"1", "2"}, sep: "", reg: regexp.MustCompile(`\d+`), l: 2, removeEmpty: false}, args: args{s: "a11b22c33d"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &PreSplitIterator{
 				a:           tt.fields.a,
-				head:        tt.fields.head,
-				tail:        tt.fields.tail,
 				sep:         tt.fields.sep,
 				reg:         tt.fields.reg,
 				l:           tt.fields.l,
@@ -172,8 +152,6 @@ func TestPreSplitIterator_Reset(t *testing.T) {
 			p.Reset(tt.args.s)
 
 			as := assert.New(t)
-			as.Equal(0, p.head)
-			as.Equal(0, p.tail)
 			as.Equal(4, p.l)
 			as.Equal([]string{"a", "b", "c", "d"}, p.a)
 			if p.reg == nil {
@@ -187,99 +165,9 @@ func TestPreSplitIterator_Reset(t *testing.T) {
 	}
 }
 
-func TestPreSplitIterator_Last(t *testing.T) {
-	type fields struct {
-		a           []string
-		head        int
-		tail        int
-		sep         string
-		reg         *regexp.Regexp
-		l           int
-		removeEmpty bool
-	}
-	tests := []struct {
-		name     string
-		fields   fields
-		wantItem string
-		wantOk   bool
-	}{
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 0, tail: 0, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: true, wantItem: "2"},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 1, tail: 0, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: true, wantItem: "2"},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 2, tail: 0, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: false, wantItem: ""},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 0, tail: -1, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: true, wantItem: "1"},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 0, tail: -2, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: false, wantItem: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &PreSplitIterator{
-				a:           tt.fields.a,
-				head:        tt.fields.head,
-				tail:        tt.fields.tail,
-				sep:         tt.fields.sep,
-				reg:         tt.fields.reg,
-				l:           tt.fields.l,
-				removeEmpty: tt.fields.removeEmpty,
-			}
-			gotItem, gotOk := p.Last()
-			if gotItem != tt.wantItem {
-				t.Errorf("Last() gotItem = %v, want %v", gotItem, tt.wantItem)
-			}
-			if gotOk != tt.wantOk {
-				t.Errorf("Last() gotOk = %v, want %v", gotOk, tt.wantOk)
-			}
-		})
-	}
-}
-
-func TestPreSplitIterator_Next(t *testing.T) {
-	type fields struct {
-		a           []string
-		head        int
-		tail        int
-		sep         string
-		reg         *regexp.Regexp
-		l           int
-		removeEmpty bool
-	}
-	tests := []struct {
-		name     string
-		fields   fields
-		wantItem string
-		wantOk   bool
-	}{
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 0, tail: 0, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: true, wantItem: "1"},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 1, tail: 0, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: true, wantItem: "2"},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 2, tail: 0, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: false, wantItem: ""},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 0, tail: -1, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: true, wantItem: "1"},
-		{name: "", fields: fields{a: []string{"1", "2"}, head: 0, tail: -2, sep: " ", reg: nil, removeEmpty: false, l: 2}, wantOk: false, wantItem: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &PreSplitIterator{
-				a:           tt.fields.a,
-				head:        tt.fields.head,
-				tail:        tt.fields.tail,
-				sep:         tt.fields.sep,
-				reg:         tt.fields.reg,
-				l:           tt.fields.l,
-				removeEmpty: tt.fields.removeEmpty,
-			}
-			gotItem, gotOk := p.Next()
-			if gotItem != tt.wantItem {
-				t.Errorf("Next() gotItem = %v, want %v", gotItem, tt.wantItem)
-			}
-			if gotOk != tt.wantOk {
-				t.Errorf("Next() gotOk = %v, want %v", gotOk, tt.wantOk)
-			}
-		})
-	}
-}
-
 func TestPreSplitIterator_ElementAt(t *testing.T) {
 	type fields struct {
 		a           []string
-		head        int
-		tail        int
 		sep         string
 		reg         *regexp.Regexp
 		l           int
@@ -295,19 +183,17 @@ func TestPreSplitIterator_ElementAt(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, head: 0, tail: 0, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: 1}, want: "1", wantErr: false},
-		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, head: 0, tail: 0, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: 4}, want: "4", wantErr: false},
-		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, head: 0, tail: 0, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: 5}, want: "", wantErr: true},
-		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, head: 0, tail: 0, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: -5}, want: "", wantErr: true},
-		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, head: 0, tail: 0, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: -4}, want: "1", wantErr: false},
-		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, head: 0, tail: 0, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: -1}, want: "4", wantErr: false},
+		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: 1}, want: "1", wantErr: false},
+		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: 4}, want: "4", wantErr: false},
+		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: 5}, want: "", wantErr: true},
+		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: -5}, want: "", wantErr: true},
+		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: -4}, want: "1", wantErr: false},
+		{name: "", fields: fields{a: []string{"1", "2", "3", "4"}, sep: " ", reg: nil, l: 4, removeEmpty: false}, args: args{idx: -1}, want: "4", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &PreSplitIterator{
 				a:           tt.fields.a,
-				head:        tt.fields.head,
-				tail:        tt.fields.tail,
 				sep:         tt.fields.sep,
 				reg:         tt.fields.reg,
 				l:           tt.fields.l,

--- a/internal/iterator/source.go
+++ b/internal/iterator/source.go
@@ -1,0 +1,93 @@
+package iterator
+
+import (
+	"bufio"
+	"encoding/csv"
+	"io"
+	"strings"
+
+	"github.com/xztaityozx/sel/internal/option"
+)
+
+// Source は入力から1行(1レコード)ずつ Columns を供給する。
+// 終端に達したら io.EOF を返す。
+// 返される Columns は次に Next を呼ぶまでのあいだだけ有効で、実体は使い回される
+type Source interface {
+	Next() (Columns, error)
+}
+
+var (
+	_ Source = (*lineSource)(nil)
+	_ Source = (*csvSource)(nil)
+)
+
+// NewSource は option.Option に従って input から Columns を供給する Source を作る
+func NewSource(option option.Option, input io.Reader) (Source, error) {
+	if ok, comma := option.IsXsv(); ok {
+		// CSV/TSVのときはencoding/csvが分割をしてくれるので、分割済みの配列をそのまま Columns にすればよい
+		r := csv.NewReader(input)
+		r.Comma = comma
+
+		return &csvSource{
+			reader:  r,
+			columns: NewPreSplitIterator("", string(comma), option.RemoveEmpty),
+		}, nil
+	}
+
+	columns, err := newSplitColumns(option)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lineSource{
+		reader:  bufio.NewReader(input),
+		columns: columns,
+	}, nil
+}
+
+// lineSource は1行ずつ読んで splitColumns に渡す Source
+type lineSource struct {
+	reader  *bufio.Reader
+	columns splitColumns
+	// 読み取り中に発生したエラー。行を返しきってから次の Next で返す
+	err error
+}
+
+func (l *lineSource) Next() (Columns, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+
+	line, err := l.reader.ReadString('\n')
+	l.err = err
+
+	if len(line) > 0 {
+		// 最終行には改行がないこともあるので、あるときだけ落とす
+		l.columns.Reset(strings.TrimRight(line, "\n"))
+		return l.columns, nil
+	}
+
+	if err == nil {
+		// ReadString は1文字以上を返すかerrorを返すので、ここには来ないはず。念のため終端にしておく
+		err = io.EOF
+		l.err = err
+	}
+
+	return nil, err
+}
+
+// csvSource は encoding/csv で1レコードずつ読む Source
+type csvSource struct {
+	reader  *csv.Reader
+	columns *PreSplitIterator
+}
+
+func (c *csvSource) Next() (Columns, error) {
+	record, err := c.reader.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	c.columns.resetFromArray(record)
+	return c.columns, nil
+}

--- a/internal/iterator/source.go
+++ b/internal/iterator/source.go
@@ -16,11 +16,6 @@ type Source interface {
 	Next() (Columns, error)
 }
 
-var (
-	_ Source = (*lineSource)(nil)
-	_ Source = (*csvSource)(nil)
-)
-
 // NewSource は option.Option に従って input から Columns を供給する Source を作る
 func NewSource(option option.Option, input io.Reader) (Source, error) {
 	if ok, comma := option.IsXsv(); ok {

--- a/internal/iterator/source_test.go
+++ b/internal/iterator/source_test.go
@@ -1,0 +1,171 @@
+package iterator
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xztaityozx/sel/internal/option"
+)
+
+func TestNewSource(t *testing.T) {
+	type args struct {
+		option option.Option
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantColumns Columns
+		wantCsv     bool
+		wantErr     bool
+	}{
+		{
+			name:        "to be lineSource with Iterator",
+			args:        args{option.Option{}},
+			wantColumns: NewIterator("", "", false),
+		},
+		{
+			name: "to be lineSource with RegexpIterator",
+			args: args{option.Option{DelimiterOption: option.DelimiterOption{
+				UseRegexp:      true,
+				InputDelimiter: `\s+`,
+			}}},
+			wantColumns: NewRegexpIterator("", regexp.MustCompile(`\s+`), false),
+		},
+		{
+			name:        "to be csvSource for CSV",
+			args:        args{option.Option{Xsv: option.Xsv{Csv: true}}},
+			wantColumns: NewPreSplitIterator("", ",", false),
+			wantCsv:     true,
+		},
+		{
+			name:        "to be csvSource for TSV",
+			args:        args{option.Option{Xsv: option.Xsv{Tsv: true}}},
+			wantColumns: NewPreSplitIterator("", "\t", false),
+			wantCsv:     true,
+		},
+		{
+			name: "fail on regexp is not invalid",
+			args: args{option.Option{DelimiterOption: option.DelimiterOption{
+				UseRegexp:      true,
+				InputDelimiter: "(", // invalid regexp
+			}}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as := assert.New(t)
+			got, err := NewSource(tt.args.option, strings.NewReader(""))
+			if tt.wantErr {
+				as.Error(err)
+				return
+			}
+
+			as.NoError(err)
+			if tt.wantCsv {
+				src, ok := got.(*csvSource)
+				as.True(ok)
+				as.Equal(tt.wantColumns, src.columns)
+			} else {
+				src, ok := got.(*lineSource)
+				as.True(ok)
+				as.Equal(tt.wantColumns, src.columns)
+			}
+		})
+	}
+}
+
+// readAll は Source を終端まで回して、各行の ToArray() を集める
+func readAll(t *testing.T, src Source) [][]string {
+	t.Helper()
+
+	var rt [][]string
+	for {
+		columns, err := src.Next()
+		if errors.Is(err, io.EOF) {
+			return rt
+		}
+		if err != nil {
+			t.Fatalf("Next() unexpected error = %v", err)
+		}
+
+		rt = append(rt, append([]string(nil), columns.ToArray()...))
+	}
+}
+
+func TestLineSource_Next(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  [][]string
+	}{
+		{name: "empty input", input: "", want: nil},
+		{name: "lines", input: "a b\nc d\n", want: [][]string{{"a", "b"}, {"c", "d"}}},
+		{name: "no trailing newline", input: "a b\nc d", want: [][]string{{"a", "b"}, {"c", "d"}}},
+		// 空行も1行として供給される。カラムは0個になる
+		{name: "empty line", input: "a b\n\nc d\n", want: [][]string{{"a", "b"}, nil, {"c", "d"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src, err := NewSource(option.Option{DelimiterOption: option.DelimiterOption{InputDelimiter: " "}}, strings.NewReader(tt.input))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, readAll(t, src))
+		})
+	}
+}
+
+func TestLineSource_Next_ReturnsReadError(t *testing.T) {
+	wantErr := errors.New("read error")
+	src := &lineSource{
+		reader:  bufio.NewReader(&errReader{s: "a b\n", err: wantErr}),
+		columns: NewIterator("", " ", false),
+	}
+
+	columns, err := src.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, columns.ToArray())
+
+	// 行を返しきったあとにエラーが返り、それ以降は何度呼んでも同じエラーになる
+	_, err = src.Next()
+	assert.ErrorIs(t, err, wantErr)
+	_, err = src.Next()
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestCsvSource_Next(t *testing.T) {
+	src, err := NewSource(option.Option{Xsv: option.Xsv{Csv: true}}, strings.NewReader("a,\"b,c\"\nd,e\n"))
+	assert.NoError(t, err)
+	assert.Equal(t, [][]string{{"a", "b,c"}, {"d", "e"}}, readAll(t, src))
+}
+
+func TestCsvSource_Next_ReturnsReadError(t *testing.T) {
+	src, err := NewSource(option.Option{Xsv: option.Xsv{Csv: true}}, strings.NewReader("a,\"b\nd,e\n"))
+	assert.NoError(t, err)
+
+	_, err = src.Next()
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, io.EOF)
+}
+
+// errReader は s を読み切ったあとに err を返す io.Reader
+type errReader struct {
+	s   string
+	err error
+}
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if e.s == "" {
+		return 0, e.err
+	}
+
+	n := copy(p, e.s)
+	e.s = e.s[n:]
+	return n, nil
+}


### PR DESCRIPTION
IEnumerable は6メソッドを持ちながら、実装によっては panic していた
(Iterator.ResetFromArray / RegexpIterator.ResetFromArray /
RegexpIterator.Last)。これが安全だったのは「CSVのときは必ず
PreSplitIterator が返る」という NewIEnumerable の暗黙の契約に支えられて
いただけで、型では何も保証されていなかった。

呼び出し元から見て本当に必要なメソッドで、インターフェースを
「行の供給」と「カラム列」に分ける。

- Columns: ElementAt / ToArray。column.Selector が見るのはこれだけ
- Source: Next() (Columns, error)。終端は io.EOF。cmd/root.go が回す
  - lineSource: bufio で1行読み、splitColumns に渡す
  - csvSource: encoding/csv で1レコード読む。分割済みなのでそのまま渡す

これにより

- ResetFromArray は csvSource の内部実装 (PreSplitIterator.resetFromArray)
  に落ちてインターフェースから消える
- Next / Last は Iterator / RegexpIterator の内部実装 (next / last) に落ちる。
  誰からも呼ばれなくなった PreSplitIterator の head/tail カーソルは削除
- panic 実装が3つとも消滅する
- cmd/root.go の run() から「CSV経路の読み取りループ」と「行読みループ」の
  二重管理が消える

バッファ再利用は Source が同じ Columns 実体を使い回すことで現状どおり維持
している。

Closes #126

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RvyfEbtRemi2RVBi3aNbGn