### PR TITLE
fix: gofmt を適用し golangci-lint に gofmt formatter を追加

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,34 +1,34 @@
 package cmd
 
 import (
-  "os"
+	"os"
 
-  "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var completionCmd = &cobra.Command{
-  Use:                   "completion [bash|zsh|fish|powershell]",
-  Short:                 "Generate completion script",
-  DisableFlagsInUseLine: true,
-  ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-  Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-  RunE: func(cmd *cobra.Command, args []string) error {
-    cmd.SilenceUsage = true
-    switch args[0] {
-    case "bash":
-      return cmd.Root().GenBashCompletion(os.Stdout)
-    case "zsh":
-      return cmd.Root().GenZshCompletion(os.Stdout)
-    case "fish":
-      return cmd.Root().GenFishCompletion(os.Stdout, true)
-    case "powershell":
-      return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-    }
-    return nil
-  },
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate completion script",
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
 }
 
 func init() {
-  rootCmd.AddCommand(completionCmd)
-  completionCmd.SetUsageTemplate(completionCmd.Use)
+	rootCmd.AddCommand(completionCmd)
+	completionCmd.SetUsageTemplate(completionCmd.Use)
 }

--- a/test/project_root.go
+++ b/test/project_root.go
@@ -6,26 +6,26 @@ import (
 )
 
 func ProjectRoot() string {
-  current, err := os.Getwd()
-  if err != nil {
-    panic(err)
-  }
+	current, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
 
-  for {
-    _, err := os.ReadFile(filepath.Join(current, "go.mod"))
-    if os.IsNotExist(err) {
-      if current == filepath.Dir(current) {
-        panic("failed to find project root")
-      }
+	for {
+		_, err := os.ReadFile(filepath.Join(current, "go.mod"))
+		if os.IsNotExist(err) {
+			if current == filepath.Dir(current) {
+				panic("failed to find project root")
+			}
 
-      current = filepath.Dir(current)
-      continue
-    } else if err != nil {
-      panic(err)
-    }
+			current = filepath.Dir(current)
+			continue
+		} else if err != nil {
+			panic(err)
+		}
 
-    break
-  }
+		break
+	}
 
-  return current
+	return current
 }


### PR DESCRIPTION
close #119 