### PR TITLE
refactor: 未使用シンボルを削除 (#120)

### DIFF
--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -97,8 +97,6 @@ const (
 	DefaultTemplate    = ""
 )
 
-type SplitStrategy int
-
 func GetOptionNames() []string {
 	return []string{
 		NameInputFiles,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -19,11 +19,11 @@ func Parse(args []string) ([]column.Selector, error) {
 		if query.isIndexQuery() {
 			querySection := strings.Split(string(query), ":")
 			if len(querySection) == 1 {
-				idx, err := strconv.Atoi(querySection[0])
+				sel, err := column.NewIndexSelectorFromString(querySection[0], 0)
 				if err != nil {
 					return nil, err
 				}
-				rt = append(rt, column.NewIndexSelector(idx))
+				rt = append(rt, sel)
 			} else if len(querySection) == 2 || len(querySection) == 3 {
 				start := 1
 				if len(querySection[0]) != 0 {


### PR DESCRIPTION
- option.SplitStrategy を削除。宣言のみでどこからも参照されていなかった
- parser.Parse の単一インデックスクエリ解析で column.NewIndexSelectorFromString を使うようにし、テストからしか呼ばれていなかった状態を解消

close #120 