### PR TITLE
refactor: parser.Parse のネストを分解しサブマッチを使い回す

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4,78 +4,95 @@ import (
 	"fmt"
 	"github.com/xztaityozx/sel/internal/column"
 	"strconv"
-	"strings"
 )
 
 func Parse(args []string) ([]column.Selector, error) {
-	queries := make(QuerySlice, 0, len(args))
-	for _, v := range args {
-		queries = append(queries, Query(v))
-	}
-
 	rt := make([]column.Selector, 0, len(args))
-	var err error
-	for _, query := range queries {
-		if query.isIndexQuery() {
-			querySection := strings.Split(string(query), ":")
-			if len(querySection) == 1 {
-				sel, err := column.NewIndexSelectorFromString(querySection[0], 0)
-				if err != nil {
-					return nil, err
-				}
-				rt = append(rt, sel)
-			} else if len(querySection) == 2 || len(querySection) == 3 {
-				start := 1
-				if len(querySection[0]) != 0 {
-					idx, err := strconv.Atoi(querySection[0])
-					if err != nil {
-						return nil, err
-					}
-					start = idx
-				}
+	for _, v := range args {
+		query := Query(v)
 
-				isInfStop := true
-				stop := start
-				if len(querySection[1]) != 0 {
-					idx, err := strconv.Atoi(querySection[1])
-					if err != nil {
-						return nil, err
-					}
-					stop = idx
-					isInfStop = false
-				}
-
-				step := 1
-				if len(querySection) == 3 && len(querySection[2]) != 0 {
-					step, err = strconv.Atoi(querySection[2])
-					if err != nil {
-						return nil, err
-					}
-				}
-
-				if step == 0 {
-					return nil, fmt.Errorf("step cannot be zero")
-				}
-
-				rt = append(rt, column.NewRangeSelector(start, step, stop, isInfStop))
+		if m := query.matchIndexQuery(); m != nil {
+			var sel column.Selector
+			var err error
+			if m[2] == "" {
+				sel, err = parseIndexQuery(query, m)
 			} else {
-				return nil, fmt.Errorf("%s is invalid index query", query)
+				sel, err = parseRangeQuery(query, m)
 			}
-		} else if query.isSwitchQuery() {
-			// sedやawkの2addrみたいなやつ
-			// /regexp/,/regexp/
-			// /regexp/,number
-			// number,/regexp/
-			s := switchQueryValidator.FindAllStringSubmatch(string(query), -1)[0]
-			ss, err := column.NewSwitchSelector(s[1], s[2])
 			if err != nil {
 				return nil, err
 			}
-			rt = append(rt, ss)
-		} else {
-			return nil, fmt.Errorf("%s is invalid query", query)
+			rt = append(rt, sel)
+			continue
 		}
+
+		if m := query.matchSwitchQuery(); m != nil {
+			sel, err := parseSwitchQuery(query, m)
+			if err != nil {
+				return nil, err
+			}
+			rt = append(rt, sel)
+			continue
+		}
+
+		return nil, fmt.Errorf("%s is invalid query", query)
 	}
 
 	return rt, nil
+}
+
+// parseIndexQuery は "1" や "-3" のような単一 index クエリをパースする
+func parseIndexQuery(query Query, m []string) (column.Selector, error) {
+	sel, err := column.NewIndexSelectorFromString(m[1], 0)
+	if err != nil {
+		return nil, fmt.Errorf("invalid index %q in query %q: %w", m[1], query, err)
+	}
+	return sel, nil
+}
+
+// parseRangeQuery は "1:10", "1:10:2", "-4:" のような range クエリをパースする
+func parseRangeQuery(query Query, m []string) (column.Selector, error) {
+	start := 1
+	if m[1] != "" {
+		v, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid start %q in query %q: %w", m[1], query, err)
+		}
+		start = v
+	}
+
+	isInfStop := true
+	stop := start
+	if m[3] != "" {
+		v, err := strconv.Atoi(m[3])
+		if err != nil {
+			return nil, fmt.Errorf("invalid stop %q in query %q: %w", m[3], query, err)
+		}
+		stop = v
+		isInfStop = false
+	}
+
+	step := 1
+	if m[4] != "" && m[5] != "" {
+		v, err := strconv.Atoi(m[5])
+		if err != nil {
+			return nil, fmt.Errorf("invalid step %q in query %q: %w", m[5], query, err)
+		}
+		step = v
+	}
+
+	if step == 0 {
+		return nil, fmt.Errorf("step cannot be zero in query %q", query)
+	}
+
+	return column.NewRangeSelector(start, step, stop, isInfStop), nil
+}
+
+// parseSwitchQuery は "/start/:/end/" のような switch (2addr) クエリをパースする
+func parseSwitchQuery(query Query, m []string) (column.Selector, error) {
+	sel, err := column.NewSwitchSelector(m[1], m[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid switch query %q: %w", query, err)
+	}
+	return sel, nil
 }

--- a/internal/parser/query.go
+++ b/internal/parser/query.go
@@ -6,7 +6,6 @@ import (
 
 // Query はクエリ文字列を表すやつ
 type Query string
-type QuerySlice []Query
 
 // start:stop:step
 // start:stop
@@ -17,10 +16,14 @@ var indexQueryValidator = regexp.MustCompile(`^(-?\d*)(:(-?\d*))?(:(-?\d*))?$`)
 // /start regexp/:endIndex
 var switchQueryValidator = regexp.MustCompile(`^(\d+|/.+/):(\+?\d+|/.+/)$`)
 
-func (q Query) isIndexQuery() bool {
-	return indexQueryValidator.MatchString(string(q))
+// matchIndexQuery はクエリが index/range クエリの形式にマッチするか判定し、
+// マッチした場合はサブマッチ結果を返す(マッチしなければ nil)
+func (q Query) matchIndexQuery() []string {
+	return indexQueryValidator.FindStringSubmatch(string(q))
 }
 
-func (q Query) isSwitchQuery() bool {
-	return switchQueryValidator.MatchString(string(q))
+// matchSwitchQuery はクエリが switch クエリの形式にマッチするか判定し、
+// マッチした場合はサブマッチ結果を返す(マッチしなければ nil)
+func (q Query) matchSwitchQuery() []string {
+	return switchQueryValidator.FindStringSubmatch(string(q))
 }


### PR DESCRIPTION
index/range/switch クエリのパースを parseIndexQuery / parseRangeQuery / parseSwitchQuery に分離し、FindStringSubmatch の結果を直接使うことで strings.Split による二重パースをなくした。あわせて strconv.Atoi の
エラーにどのクエリのどの部分が不正かを含めるようにした。

Closes #118